### PR TITLE
ux: focus on the textfield when tap search component

### DIFF
--- a/lib/app/shared/presentation/widgets/app_search_bar.dart
+++ b/lib/app/shared/presentation/widgets/app_search_bar.dart
@@ -73,6 +73,7 @@ class SearchBar extends StatefulWidget {
 class _SearchBarState extends State<SearchBar> {
   bool isExpanded = false;
 
+  late FocusNode _focusNode;
   final allItems = AllComponents.widgets;
   List<Component> filteredData = [];
   String? searchTerm;
@@ -92,6 +93,19 @@ class _SearchBarState extends State<SearchBar> {
       searchTerm = title;
       filteredData = data;
     });
+  }
+
+  @override
+  void initState() {
+    _focusNode = FocusNode();
+    _focusNode.requestFocus();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
   }
 
   @override
@@ -120,6 +134,7 @@ class _SearchBarState extends State<SearchBar> {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       child: TextField(
+                        focusNode: _focusNode,
                         onChanged: filter,
                         style: const TextStyle(fontSize: 14),
                         decoration: InputDecoration(


### PR DESCRIPTION
a minor improve for user experience

before: you tap the search component field,the textfield apears without focus,you need to tap again

[Screencast from 2024-12-12 22-59-11.webm](https://github.com/user-attachments/assets/1914bc1a-844f-4ea9-a8af-2cdab523fb6f)



after: when tap the search component field,the  textfield appears with focus.

[Screencast from 2024-12-12 22-56-53.webm](https://github.com/user-attachments/assets/cb9a03ec-50c8-4dd6-9bdf-12cdcc0dfedc)



